### PR TITLE
Various fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN tar -C /opt -xzf /opt/teamspeak3-server_linux-amd64-3*.tar.gz
 ADD /scripts/ /opt/scripts/
 RUN chmod -R 774 /opt/scripts/
 
+# Cleanup
+RUN rm -f /opt/teamspeak3-server_linux-amd64-3*.tar.gz
+
 ENTRYPOINT ["/opt/scripts/docker-ts3.sh"]
 #CMD ["-w", "/teamspeak3/query_ip_whitelist.txt", "-b", "/teamspeak3/query_ip_blacklist.txt", "-o", "/teamspeak3/logs/", "-l", "/teamspeak3/"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ VOLUME ["/teamspeak3"]
 
 # Download TS3 file and extract it into /opt.
 ADD ${TEAMSPEAK_URL} /opt/
-RUN cd /opt && tar -xzf /opt/teamspeak3-server_linux-amd64-3*.tar.gz
+RUN tar -C /opt -xzf /opt/teamspeak3-server_linux-amd64-3*.tar.gz
 
 ADD /scripts/ /opt/scripts/
 RUN chmod -R 774 /opt/scripts/

--- a/scripts/docker-ts3.sh
+++ b/scripts/docker-ts3.sh
@@ -34,7 +34,7 @@ else
 		query_ip_whitelist="/teamspeak3/query_ip_whitelist.txt" \
 		query_ip_backlist="/teamspeak3/query_ip_blacklist.txt" \
 		logpath="/teamspeak3/logs/" \
-		licensepath="/teamspeak3/" 
+		licensepath="/teamspeak3/" \
 		inifile="/teamspeak3/ts3server.ini" \
 		createinifile=1 
 fi


### PR DESCRIPTION
A typo in the startup script prevented the ini file from being created.

Using tar -C is mostly just cosmetic, but it might be slightly better for caching.

Removing the archive should make for a slightly smaller image.
