### PR TITLE
Rework Dockerfile to decrease image size and improve caching.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,22 +8,26 @@ FROM ubuntu
 
 MAINTAINER Alex
 
+RUN apt-get update \
+        && apt-get install -y wget --no-install-recommends \
+        && rm -r /var/lib/apt/lists/*
+
 ## Set some variables for override.
 # Download Link of TS3 Server
-ENV TEAMSPEAK_URL http://dl.4players.de/ts/releases/3.0.11.4/teamspeak3-server_linux-amd64-3.0.11.4.tar.gz
+ENV TEAMSPEAK_VERSION 3.0.11.4
+ENV TEAMSPEAK_SHA1 09e7fc2cb5dddf84f3356ddd555ad361f5854321
 
 # Inject a Volume for any TS3-Data that needs to be persisted or to be accessible from the host. (e.g. for Backups)
 VOLUME ["/teamspeak3"]
 
 # Download TS3 file and extract it into /opt.
-ADD ${TEAMSPEAK_URL} /opt/
-RUN tar -C /opt -xzf /opt/teamspeak3-server_linux-amd64-3*.tar.gz
+RUN wget -O teamspeak3-server_linux-amd64.tar.gz http://dl.4players.de/ts/releases/${TEAMSPEAK_VERSION}/teamspeak3-server_linux-amd64-${TEAMSPEAK_VERSION}.tar.gz \
+        && echo "${TEAMSPEAK_SHA1} *teamspeak3-server_linux-amd64.tar.gz" | sha1sum -c - \
+        && tar -C /opt -xzf teamspeak3-server_linux-amd64.tar.gz \
+        && rm teamspeak3-server_linux-amd64.tar.gz
 
 ADD /scripts/ /opt/scripts/
 RUN chmod -R 774 /opt/scripts/
-
-# Cleanup
-RUN rm -f /opt/teamspeak3-server_linux-amd64-3*.tar.gz
 
 ENTRYPOINT ["/opt/scripts/docker-ts3.sh"]
 #CMD ["-w", "/teamspeak3/query_ip_whitelist.txt", "-b", "/teamspeak3/query_ip_blacklist.txt", "-o", "/teamspeak3/logs/", "-l", "/teamspeak3/"]


### PR DESCRIPTION
Previously we were removing the TS3 tarball, but because of layering it didn't save any space. Downloading and removing it in with a single command means it never makes it into a layer.

This also verifies the SHA1 of the downloaded file.
