### PR TITLE
always link database to host-mounted directory for persistence

### DIFF
--- a/scripts/docker-ts3.sh
+++ b/scripts/docker-ts3.sh
@@ -2,12 +2,8 @@
 VOLUME=/teamspeak3
 
 echo " ----- docker-ts3 ------"
-echo "1. Check if ts3server.sqlitedb exists in host-mounted volume."
-if [ -f $VOLUME/ts3server.sqlitedb ]
-  then
-    echo "$VOLUME/ts3server.sqlitedb found. Creating Link between host-mounted db-file and ts3-folder."
-	ln -s $VOLUME/ts3server.sqlitedb /opt/teamspeak3-server_linux-amd64/ts3server.sqlitedb 
-fi
+echo "1. Linking host mounted database"
+ln -s $VOLUME/ts3server.sqlitedb /opt/teamspeak3-server_linux-amd64/ts3server.sqlitedb 
 
 echo "2. Link the files-folder into the host-mounted volume."
 mkdir -p /teamspeak3/files


### PR DESCRIPTION
Not sure if it's intentional or not but as it stands the database itself is not linked if it is created inside the container. This means that, while all the other data is persisted, the database is not even when using a persistent volume. This changes it so that the database is always persisted in the `/teamspeak3` directory regardless of whether a file already exists there before starting the container or not.
