### PR TITLE
Fixed restart of container

### DIFF
--- a/docker-ts3.sh
+++ b/docker-ts3.sh
@@ -10,7 +10,9 @@ fi
 
 echo "- Linking host mounted database..."
 
-ln -s $VOLUME/ts3server.sqlitedb /opt/teamspeak3-server_linux_amd64/ts3server.sqlitedb
+if ! [ -L /opt/teamspeak3-server_linux_amd64/ts3server.sqlitedb ]; then
+  ln -s $VOLUME/ts3server.sqlitedb /opt/teamspeak3-server_linux_amd64/ts3server.sqlitedb
+fi
 
 echo "- Link the files-folder into the host-mounted volume..."
 


### PR DESCRIPTION
Because the link to the database is already created at the first start, it will fail on the second.

This fix will only create the link if it is not already created.