### PR TITLE
Run as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 
 LABEL maintainer Knut Ahlers <knut@ahlers.me>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV TEAMSPEAK_VERSION=3.13.7 \
 
 SHELL ["/bin/bash", "-exo", "pipefail",  "-c"]
 RUN apt-get update \
- && apt-get install -y curl bzip2 ca-certificates --no-install-recommends \
+ && apt-get install -y curl bzip2 ca-certificates dumb-init --no-install-recommends \
  && curl -sSfLo teamspeak3-server_linux-amd64.tar.bz2 \
       "https://files.teamspeak-services.com/releases/server/${TEAMSPEAK_VERSION}/teamspeak3-server_linux_amd64-${TEAMSPEAK_VERSION}.tar.bz2" \
  && echo "${TEAMSPEAK_SHA256} *teamspeak3-server_linux-amd64.tar.bz2" | sha256sum -c - \
@@ -23,6 +23,7 @@ COPY docker-ts3.sh /opt/docker-ts3.sh
 # Inject a Volume for any TS3-Data that needs to be persisted or to be accessible from the host. (e.g. for Backups)
 VOLUME ["/teamspeak3"]
 
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/opt/docker-ts3.sh"]
 
 # Expose the Standard TS3 port, for files, for serverquery

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,23 +6,26 @@ LABEL maintainer Knut Ahlers <knut@ahlers.me>
 ENV TEAMSPEAK_VERSION=3.13.7 \
     TEAMSPEAK_SHA256=775a5731a9809801e4c8f9066cd9bc562a1b368553139c1249f2a0740d50041e
 
-SHELL ["/bin/bash", "-exo", "pipefail",  "-c"]
 RUN apt-get update \
  && apt-get install -y curl bzip2 ca-certificates dumb-init --no-install-recommends \
  && curl -sSfLo teamspeak3-server_linux-amd64.tar.bz2 \
-      "https://files.teamspeak-services.com/releases/server/${TEAMSPEAK_VERSION}/teamspeak3-server_linux_amd64-${TEAMSPEAK_VERSION}.tar.bz2" \
+    "https://files.teamspeak-services.com/releases/server/${TEAMSPEAK_VERSION}/teamspeak3-server_linux_amd64-${TEAMSPEAK_VERSION}.tar.bz2" \
  && echo "${TEAMSPEAK_SHA256} *teamspeak3-server_linux-amd64.tar.bz2" | sha256sum -c - \
  && tar -C /opt -xjf teamspeak3-server_linux-amd64.tar.bz2 \
  && rm teamspeak3-server_linux-amd64.tar.bz2 \
  && apt-get purge -y curl bzip2 && apt-get autoremove -y \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd -g 1000 teamspeak \
+ && useradd -u 1000 -g 1000 teamspeak \
+ && chown -R teamspeak:teamspeak /opt/teamspeak3-server_linux_amd64
 
 COPY docker-ts3.sh /opt/docker-ts3.sh
 
 # Inject a Volume for any TS3-Data that needs to be persisted or to be accessible from the host. (e.g. for Backups)
 VOLUME ["/teamspeak3"]
 
+USER teamspeak
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/opt/docker-ts3.sh"]
 


### PR DESCRIPTION
* update base image to debian bullseye
* add [dumb-init](https://github.com/Yelp/dumb-init) entrypoint for clean container stop
* run as unprivileged user